### PR TITLE
Prevent invalid page navigation and tidy hook

### DIFF
--- a/src/components/PageSelect/index.tsx
+++ b/src/components/PageSelect/index.tsx
@@ -13,6 +13,8 @@ export const PageSelect = ({
   pageNumber,
   handlePage,
 }: PageSelectProps) => {
+  const isFirstPage = page <= 1
+  const isLastPage = page >= pageNumber
   const handleClickNext: React.MouseEventHandler<HTMLButtonElement> = () => {
     const nextPage = page + 1
     if (nextPage <= pageNumber && handlePage) {
@@ -29,9 +31,13 @@ export const PageSelect = ({
   }
   return (
     <S.WrapperPageSelect>
-      <Button onClick={handleClickPrevious}>Anterior</Button>
+      <Button onClick={handleClickPrevious} disabled={isFirstPage}>
+        Anterior
+      </Button>
       <S.Page>{page}</S.Page>
-      <Button onClick={handleClickNext}>Próxima</Button>
+      <Button onClick={handleClickNext} disabled={isLastPage}>
+        Próxima
+      </Button>
     </S.WrapperPageSelect>
   )
 }

--- a/src/components/PageSelect/pageSelect.test.tsx
+++ b/src/components/PageSelect/pageSelect.test.tsx
@@ -13,4 +13,18 @@ describe("< PageSelect />", () => {
     const page = screen.getByText("1")
     expect(page).toBeInTheDocument()
   })
+
+  it("Should disable previous button on first page", () => {
+    render(<PageSelect page={1} pageNumber={10} />)
+
+    const leftButton = screen.getByText("Anterior")
+    expect(leftButton).toBeDisabled()
+  })
+
+  it("Should disable next button on last page", () => {
+    render(<PageSelect page={10} pageNumber={10} />)
+
+    const rightButton = screen.getByText("Próxima")
+    expect(rightButton).toBeDisabled()
+  })
 })

--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -9,10 +9,10 @@ interface IUseData {
   page: number
   setPage: React.Dispatch<React.SetStateAction<number>>
 }
-const initialSate = { films: [], pageNumber: 0 }
+const initialState = { films: [], pageNumber: 0 }
 
 export function useData(): IUseData {
-  const [data, setData] = useState<IData>(initialSate)
+  const [data, setData] = useState<IData>(initialState)
   const [page, setPage] = useState(1)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(false)
@@ -25,7 +25,7 @@ export function useData(): IUseData {
       setError(false)
     } catch (err) {
       console.error(err)
-      setData(initialSate)
+      setData(initialState)
       setError(true)
     }
     setLoading(false)


### PR DESCRIPTION
## Summary
- disable PageSelect buttons when on the first or last page
- rename useData initial state constant
- add unit tests for disabled navigation

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895e724e9608326a1022ffbbfc2be85